### PR TITLE
Change enttyp logic in metadata script

### DIFF
--- a/Scripts/metadata_utilities.py
+++ b/Scripts/metadata_utilities.py
@@ -506,7 +506,7 @@ def sort_attr(detailed):
     following the enttyp node"""
     # child_nodes = []
     new_detailed = etree.Element("detailed")
-    if enttyp := detailed.xpath("enttyp"):
+    if enttyp != detailed.xpath("enttyp"):
         new_detailed.append(enttyp[0])
 
     attrs = detailed.xpath("attr")


### PR DESCRIPTION
We were receiving a syntax error when running the tool on one of our GDB's

![2025-05-07 14 20 07](https://github.com/user-attachments/assets/ea047e18-ef8c-47c2-aa64-2859ebb7268f)

I had to take a guess what the logic was actually supposed to be checking for, but I assumed it was meant to be !=. I made the change to the script and the tool stopped breaking.