### PR TITLE
Fix Bug that crashes tool if Feature classes to project parameter is used.

### DIFF
--- a/Scripts/GeMS_ProjectCrossSectionData_AGP2.py
+++ b/Scripts/GeMS_ProjectCrossSectionData_AGP2.py
@@ -481,7 +481,7 @@ if project_all:
         v["catalogPath"] for v in fd_dict.values() if v["shapeType"] == "Point"
     ]
 else:
-    featureClassesToProject = fcToProject.split(";")
+    featureClassesToProject = fcToProject.replace("'","").split(";")
     for fc in featureClassesToProject:
         desc = arcpy.da.Describe(fc)
         fc_name = os.path.basename(fc)

--- a/Scripts/GeMS_ProjectCrossSectionData_AGP2.py
+++ b/Scripts/GeMS_ProjectCrossSectionData_AGP2.py
@@ -481,8 +481,9 @@ if project_all:
         v["catalogPath"] for v in fd_dict.values() if v["shapeType"] == "Point"
     ]
 else:
-    featureClassesToProject = fcToProject.replace("'","").split(";")
+    featureClassesToProject = fcToProject.split(";")
     for fc in featureClassesToProject:
+        fc = fc.strip('\'"')
         desc = arcpy.da.Describe(fc)
         fc_name = os.path.basename(fc)
         if desc["shapeType"] == "Polyline":


### PR DESCRIPTION
Project Map Data to Cross Section crashes if a user leaves `Project all features in GeologicMap` unchecked and specifies one or more feature layers in `Feature Classes to Project`. The error message is:

>line 486, in <module>
﻿    desc = arcpy.da.Describe(fc)
﻿           ^^^^^^^^^^^^^^^^^^^^^
﻿ValueError: Object: Error in accessing describe

This is happening due to a parsing issue. Project all features in GeologicMap passes a semi-colon delimited string with single quotation marks around each item. The existing code used `.split(';')` to create a list of feature classes but each list item included additional single quotes and did not represent a valid file path. Removing the extra quotation marks with `replace` resolves the issue.