### PR TITLE
V2 Build Metadata does not parse compound DataSourceIDs correctly

### DIFF
--- a/Scripts/GeMS_FGDCMetadata.py
+++ b/Scripts/GeMS_FGDCMetadata.py
@@ -137,7 +137,7 @@ def catch_m2m(dictionary, field_value):
             for src_id in src_ids:
                 src_id = src_id.strip()
                 if src_id in dictionary:
-                    defs.append(dictionary[src_id][0])
+                    defs.append(dictionary[src_id])
                 else:
                     defs.append(f"PROVIDE A DEFINITION FOR {src_id}")
             def_str = " | ".join(defs)


### PR DESCRIPTION
V2 of the GeMS Toolbox allows for multiple DataSourceID values separated by pipe "|" characters. For example, `SIM_3035|SIM_2863`. However, the Build Metadata tool does not quite create metadata for DataSourceID fields in the detailed entity-attribute section correctly. Typically, the tool sets these fields as having enumerated values, listing each dataSourceID as a value, and using the actual full source as the enumerated value definition.

However, when a compound data source is used, the enumerated value definition only retains the first character of each source. So `SIM_3035|SIM_2863` is defined as `B | B`. This is because each of those sources starts with an author whose last name starts with B.

This one line fix I am submitting corrects the issue. When the code in function catch_m2m gets DataSource information from the DataSource dictionary, it was using string indexing to get the first character of the source rather than the entire source. I do not think this was intended.