### PR TITLE
fix two validate database checks that never ran

### DIFF
--- a/Scripts/GeMS_ValidateDatabase.py
+++ b/Scripts/GeMS_ValidateDatabase.py
@@ -142,7 +142,7 @@ def compare_sr(obj1, obj2, db_dict):
     not error"""
     sr_warnings = []
     sr1 = db_dict[obj1]["spatialReference"].name
-    sr2 = db_dict[obj1]["spatialReference"].name
+    sr2 = db_dict[obj2]["spatialReference"].name
     if sr1 != sr2:
         sr_warnings = [f"{obj1} and {obj2} have different spatial references"]
     else:
@@ -1897,7 +1897,7 @@ def main(argv):
         src_md.exportMetadata(str(metadata_file), "FGDC_CSDGM")
 
     if metadata_file:
-        if Path(metadata_file).exists:
+        if Path(metadata_file).exists():
             md_summary = validate_w_mp(metadata_file, workdir)
         else:
             md_summary = f"{metadata_file} does not exist."


### PR DESCRIPTION
Two checks in `GeMS_ValidateDatabase.py` never actually ran. Checks would always pass even if dataset was not correct.

`compare_sr()` meant to flag when two feature classes use different spatial references but it was reading both spatial refs from the first feature class:

```python
sr1 = db_dict[obj1]["spatialReference"].name
sr2 = db_dict[obj1]["spatialReference"].name   # should be obj2
```

So it always compared a feature class to itself and never reported a mismatch. 

Also, metadata check used `Path(metadata_file).exists` ie the method itself. "Does not exist" branch would never run and `validate_w_mp()` was passed missing file. Now calls `.exists()` with parentheses

Verified with ArcGIS Pro 3.6.1 with WSGS GeMS gdbs.

The affected lines are the same on `master` and `Version-3`.
